### PR TITLE
fix: avoid passing null parameter to createTextNode on php 8.1

### DIFF
--- a/Verdant/Array2XML.php
+++ b/Verdant/Array2XML.php
@@ -201,7 +201,7 @@ class Array2XML
 
         // after we are done with all the keys in the array (if it is one)
         // we check if it has any text value, if yes, append it.
-        if ( ! is_array($array)) {
+        if ( ! is_array($array) && isset($array)) {
             $node->appendChild($xml->createTextNode($this->bool2str($array)));
         }
 

--- a/Verdant/Array2XML.php
+++ b/Verdant/Array2XML.php
@@ -201,7 +201,7 @@ class Array2XML
 
         // after we are done with all the keys in the array (if it is one)
         // we check if it has any text value, if yes, append it.
-        if ( ! is_array($array) && isset($array)) {
+        if ( ! is_array($array) && $array) {
             $node->appendChild($xml->createTextNode($this->bool2str($array)));
         }
 


### PR DESCRIPTION
Deprecated message: `Deprecated: DOMDocument::createTextNode(): Passing null to parameter #1 ($data) of type string is deprecated in /Users/minilo/Code/shipment-label-api/vendor/verdant/xml2array/Verdant/Array2XML.php on line 205`

[domdocument.createtextnode at PHP.net](https://www.php.net/manual/en/domdocument.createtextnode.php)